### PR TITLE
 Fixed alarm edit window in 12 hour mode

### DIFF
--- a/src/win-edit.c
+++ b/src/win-edit.c
@@ -210,13 +210,25 @@ static void back_click_handler(ClickRecognizerRef recognizer, void *context) {
 }
 
 static void up_click_handler(ClickRecognizerRef recognizer, void *context) {
-  s_digits[s_selection] += (s_digits[s_selection] == s_max[s_selection]) ? -s_max[s_selection] : 1;
+  if(s_selection == 0 && s_withampm && s_digits[s_selection] == s_max[s_selection] - 1)
+    s_digits[2] = !s_digits[2];
   
+  s_digits[s_selection] += s_digits[s_selection] == s_max[s_selection] ? -s_max[s_selection] : 1;
+
+  if(s_selection == 0 && s_withampm && s_digits[0] == 0)
+    s_digits[0] = 1;
+	
   layer_mark_dirty(s_canvas_layer);
 }
 
 static void down_click_handler(ClickRecognizerRef recognizer, void *context) {
+  if(s_selection == 0 && s_withampm && s_digits[s_selection] == s_max[s_selection])
+    s_digits[2] = !s_digits[2];
+	  
   s_digits[s_selection] -= (s_digits[s_selection] == 0) ? -s_max[s_selection] : 1;
+	
+  if(s_selection == 0 && s_withampm && s_digits[0] == 0)
+    s_digits[0] = s_max[0];
   
   layer_mark_dirty(s_canvas_layer);
 }


### PR DESCRIPTION
It was previously going to 0 when you were in 12 hour mode and tried to go from 12 to 1 or 1 to 12

Also added functionality like the built in alarms time picker. It now changes AM/PM based on 11->12 transitions.
